### PR TITLE
Add static Shogi AI web app skeleton

### DIFF
--- a/Board.js
+++ b/Board.js
@@ -1,0 +1,255 @@
+const LETTERS = 'abcdefghi';
+
+function pieceChar(piece) {
+  const map = {
+    P: '歩', L: '香', N: '桂', S: '銀', G: '金',
+    B: '角', R: '飛', K: '玉',
+    '+P': 'と', '+L': '杏', '+N': '圭', '+S': '全',
+    '+B': '馬', '+R': '龍'
+  };
+  const key = piece.promoted ? '+' + piece.type : piece.type;
+  return map[key] || '';
+}
+
+export default class Board {
+  constructor(elem) {
+    this.elem = elem;
+    this.reset();
+  }
+
+  reset() {
+    this.side = 'b';
+    this.hands = { b: {}, w: {} };
+    this.history = [];
+    this.board = this.parseSFEN(
+      'lnsgkgsnl/1r5b1/p1ppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL'
+    );
+    this.render();
+  }
+
+  parseSFEN(str) {
+    const rows = str.split('/');
+    const board = [];
+    for (let y = 0; y < 9; y++) {
+      const row = [];
+      let idx = 0;
+      for (const ch of rows[y]) {
+        if (/[1-9]/.test(ch)) {
+          const cnt = parseInt(ch, 10);
+          for (let i = 0; i < cnt; i++) row.push(null);
+        } else {
+          const owner = ch === ch.toUpperCase() ? 'b' : 'w';
+          row.push({ type: ch.toUpperCase(), owner, promoted: false });
+        }
+        idx++;
+      }
+      board.push(row);
+    }
+    return board;
+  }
+
+  render() {
+    this.elem.innerHTML = '';
+    for (let y = 0; y < 9; y++) {
+      for (let x = 0; x < 9; x++) {
+        const cell = document.createElement('div');
+        cell.className = 'cell';
+        cell.dataset.x = x;
+        cell.dataset.y = y;
+        cell.addEventListener('dragover', e => e.preventDefault());
+        cell.addEventListener('drop', e => this.onDrop(e));
+        const p = this.board[y][x];
+        if (p) {
+          const div = document.createElement('div');
+          div.className = 'piece ' + p.owner;
+          div.draggable = true;
+          div.dataset.x = x;
+          div.dataset.y = y;
+          div.addEventListener('dragstart', e => this.onDragStart(e));
+          div.textContent = pieceChar(p);
+          cell.appendChild(div);
+        }
+        this.elem.appendChild(cell);
+      }
+    }
+  }
+
+  onDragStart(e) {
+    const x = e.target.dataset.x;
+    const y = e.target.dataset.y;
+    e.dataTransfer.setData('text/plain', JSON.stringify({ x, y }));
+    const moves = this.legalMoves(parseInt(x), parseInt(y));
+    this.highlight(moves);
+  }
+
+  onDrop(e) {
+    const data = JSON.parse(e.dataTransfer.getData('text/plain'));
+    const toX = parseInt(e.currentTarget.dataset.x);
+    const toY = parseInt(e.currentTarget.dataset.y);
+    const fromX = parseInt(data.x);
+    const fromY = parseInt(data.y);
+    const moves = this.legalMoves(fromX, fromY);
+    if (moves.some(m => m.x === toX && m.y === toY)) {
+      this.move(fromX, fromY, toX, toY);
+    }
+    this.clearHighlight();
+  }
+
+  move(fx, fy, tx, ty) {
+    const piece = this.board[fy][fx];
+    this.board[fy][fx] = null;
+    const captured = this.board[ty][tx];
+    if (captured) {
+      captured.owner = piece.owner;
+      captured.promoted = false;
+      this.addHand(piece.owner, captured.type);
+    }
+    this.board[ty][tx] = piece;
+    this.history.push({ fx, fy, tx, ty, captured });
+    this.side = this.side === 'b' ? 'w' : 'b';
+    this.render();
+  }
+
+  undo() {
+    const last = this.history.pop();
+    if (!last) return;
+    const { fx, fy, tx, ty, captured } = last;
+    const piece = this.board[ty][tx];
+    this.board[fy][fx] = piece;
+    this.board[ty][tx] = captured || null;
+    if (captured) {
+      this.hands[piece.owner][captured.type]--;
+    }
+    this.side = this.side === 'b' ? 'w' : 'b';
+    this.render();
+    this.updateHands();
+  }
+
+  addHand(owner, type) {
+    this.hands[owner][type] = (this.hands[owner][type] || 0) + 1;
+    this.updateHands();
+  }
+
+  updateHands() {
+    const bdiv = document.getElementById('hand-b');
+    const wdiv = document.getElementById('hand-w');
+    bdiv.textContent = '先手持ち駒: ' + this.formatHand(this.hands.b);
+    wdiv.textContent = '後手持ち駒: ' + this.formatHand(this.hands.w);
+  }
+
+  getSFEN() {
+    let rows = [];
+    for (let y = 0; y < 9; y++) {
+      let empty = 0;
+      let row = '';
+      for (let x = 0; x < 9; x++) {
+        const p = this.board[y][x];
+        if (!p) {
+          empty++;
+        } else {
+          if (empty) { row += empty; empty = 0; }
+          const ch = p.type;
+          row += p.owner === 'b' ? ch : ch.toLowerCase();
+        }
+      }
+      if (empty) row += empty;
+      rows.push(row);
+    }
+    const hand = this.formatSFENHand();
+    return `${rows.join('/')}` + ` ${this.side === 'b' ? 'b' : 'w'} ${hand || '-'}`;
+  }
+
+  formatSFENHand() {
+    const order = ['R','B','G','S','N','L','P'];
+    let str = '';
+    for (const owner of ['b','w']) {
+      for (const p of order) {
+        const c = this.hands[owner][p] || 0;
+        if (c) str += (c > 1 ? c : '') + (owner === 'b' ? p : p.toLowerCase());
+      }
+    }
+    return str;
+  }
+
+  formatHand(hand) {
+    return Object.entries(hand)
+      .map(([k, v]) => pieceChar({ type: k, owner: 'b' }) + (v > 1 ? v : ''))
+      .join(' ');
+  }
+
+  highlight(moves) {
+    for (const m of moves) {
+      const selector = `.cell[data-x="${m.x}"][data-y="${m.y}"]`;
+      const cell = this.elem.querySelector(selector);
+      if (cell) cell.classList.add('highlight');
+    }
+  }
+
+  clearHighlight() {
+    this.elem.querySelectorAll('.highlight').forEach(c => c.classList.remove('highlight'));
+  }
+
+  legalMoves(x, y) {
+    const p = this.board[y][x];
+    if (!p || p.owner !== this.side) return [];
+    const dirs = this.getPieceMoves(p);
+    const moves = [];
+    for (const d of dirs.steps || []) {
+      const dx = d[0];
+      const dy = p.owner === 'b' ? d[1] : -d[1];
+      const nx = x + dx;
+      const ny = y + dy;
+      if (nx < 0 || nx >= 9 || ny < 0 || ny >= 9) continue;
+      const target = this.board[ny][nx];
+      if (!target || target.owner !== p.owner) moves.push({ x: nx, y: ny });
+    }
+    for (const d of dirs.slides || []) {
+      const dx = d[0];
+      const dy = p.owner === 'b' ? d[1] : -d[1];
+      let nx = x + dx;
+      let ny = y + dy;
+      while (nx >= 0 && nx < 9 && ny >= 0 && ny < 9) {
+        const target = this.board[ny][nx];
+        if (!target) {
+          moves.push({ x: nx, y: ny });
+        } else {
+          if (target.owner !== p.owner) moves.push({ x: nx, y: ny });
+          break;
+        }
+        nx += dx;
+        ny += dy;
+      }
+    }
+    for (const d of dirs.jumps || []) {
+      const dx = d[0];
+      const dy = p.owner === 'b' ? d[1] : -d[1];
+      const nx = x + dx;
+      const ny = y + dy;
+      if (nx < 0 || nx >= 9 || ny < 0 || ny >= 9) continue;
+      const target = this.board[ny][nx];
+      if (!target || target.owner !== p.owner) moves.push({ x: nx, y: ny });
+    }
+    return moves;
+  }
+
+  getPieceMoves(piece) {
+    const G = { steps: [[0,-1],[-1,-1],[1,-1],[-1,0],[1,0],[0,1]] };
+    const data = {
+      P: { steps: [[0,-1]] },
+      L: { slides: [[0,-1]] },
+      N: { jumps: [[-1,-2],[1,-2]] },
+      S: { steps: [[0,-1],[-1,-1],[1,-1],[-1,1],[1,1]] },
+      G,
+      B: { slides: [[-1,-1],[1,-1],[-1,1],[1,1]] },
+      R: { slides: [[0,-1],[0,1],[-1,0],[1,0]] },
+      K: { steps: [[0,-1],[0,1],[-1,0],[1,0],[-1,-1],[1,-1],[-1,1],[1,1]] },
+      '+P': G,
+      '+L': G,
+      '+N': G,
+      '+S': G,
+      '+B': { slides: [[-1,-1],[1,-1],[-1,1],[1,1]], steps: [[0,-1],[0,1],[-1,0],[1,0]] },
+      '+R': { slides: [[0,-1],[0,1],[-1,0],[1,0]], steps: [[-1,-1],[1,-1],[-1,1],[1,1]] }
+    };
+    return data[piece.promoted ? '+' + piece.type : piece.type] || { steps: [] };
+  }
+}

--- a/Engine.js
+++ b/Engine.js
@@ -1,0 +1,20 @@
+export default class Engine {
+  constructor(depth = 4) {
+    this.depth = depth;
+    this.worker = new Worker('engineWorker.js', { type: 'module' });
+  }
+
+  async init() {
+    return new Promise(resolve => {
+      this.worker.onmessage = e => {
+        if (e.data.type === 'ready') resolve();
+        if (e.data.type === 'bestmove' && this.onBestMove) this.onBestMove(e.data.move);
+      };
+      this.worker.postMessage({ type: 'init' });
+    });
+  }
+
+  go(sfen, moves) {
+    this.worker.postMessage({ type: 'go', sfen, moves, depth: this.depth });
+  }
+}

--- a/app.js
+++ b/app.js
@@ -1,0 +1,36 @@
+import Board from './Board.js';
+import Engine from './Engine.js';
+
+const boardElem = document.getElementById('board');
+const board = new Board(boardElem);
+const levelSelect = document.getElementById('level');
+const turnSpan = document.getElementById('turn');
+const messageDiv = document.getElementById('message');
+const undoBtn = document.getElementById('undo');
+const resetBtn = document.getElementById('reset');
+
+let engine = new Engine(parseInt(levelSelect.value));
+engine.init();
+engine.onBestMove = move => {
+  messageDiv.textContent = '';
+  // TODO: apply best move
+};
+
+levelSelect.addEventListener('change', () => {
+  engine = new Engine(parseInt(levelSelect.value));
+  engine.init();
+});
+
+undoBtn.addEventListener('click', () => {
+  board.undo();
+});
+
+resetBtn.addEventListener('click', () => {
+  board.reset();
+});
+
+boardElem.addEventListener('drop', () => {
+  turnSpan.textContent = board.side === 'b' ? '先手番' : '後手番';
+  messageDiv.textContent = 'AI 思考中...';
+  engine.go(board.getSFEN(), []);
+});

--- a/engineWorker.js
+++ b/engineWorker.js
@@ -1,0 +1,19 @@
+let engine;
+
+async function initEngine() {
+  const response = await fetch('engine/yaneuraou.wasm');
+  const wasm = await WebAssembly.instantiateStreaming(response, {});
+  engine = wasm.instance.exports;
+  postMessage({ type: 'ready' });
+}
+
+onmessage = async e => {
+  const msg = e.data;
+  if (msg.type === 'init') {
+    initEngine();
+  } else if (msg.type === 'go') {
+    // Placeholder: actual USI not implemented
+    // return random move
+    postMessage({ type: 'bestmove', move: '' });
+  }
+};

--- a/index.html
+++ b/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <title>ブラウザ将棋 (人間 vs AI)</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h1>ブラウザ将棋 (人間 vs AI)</h1>
+  <div id="controls">
+    <label>難易度:
+      <select id="level">
+        <option value="2">Easy</option>
+        <option value="4" selected>Normal</option>
+        <option value="6">Hard</option>
+      </select>
+    </label>
+    <button id="reset">リセット</button>
+    <button id="undo">Undo</button>
+    <span id="turn">先手番</span>
+  </div>
+  <div id="board" class="board"></div>
+  <div id="hand-b" class="hand">先手持ち駒:</div>
+  <div id="hand-w" class="hand">後手持ち駒:</div>
+  <div id="message"></div>
+  <script type="module" src="app.js"></script>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,27 @@
+body { font-family: sans-serif; }
+.board {
+  display: grid;
+  grid-template-columns: repeat(9, 60px);
+  grid-template-rows: repeat(9, 60px);
+  border: 1px solid #333;
+  width: 540px;
+  margin-bottom: 10px;
+}
+.cell {
+  width: 60px;
+  height: 60px;
+  border: 1px solid #999;
+  position: relative;
+}
+.piece {
+  font-size: 40px;
+  text-align: center;
+  line-height: 60px;
+  user-select: none;
+  cursor: grab;
+}
+.piece.w { transform: rotate(180deg); }
+.highlight { background: rgba(255, 255, 0, 0.5); }
+.hand {
+  margin: 5px 0;
+}


### PR DESCRIPTION
## Summary
- add a minimal Japanese Shogi UI
- use drag & drop pieces and highlight legal moves
- include placeholders for the YaneuraOu WASM engine

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686bcd2b6a208325a7a5f7680684f0e5