### PR TITLE
Add simple AI shogi web app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+/tmp

--- a/app.js
+++ b/app.js
@@ -1,0 +1,112 @@
+let state = null;
+
+function pieceKanji(kind) {
+  const map = {FU:"歩",KY:"香",KE:"桂",GI:"銀",KI:"金",KA:"角",HI:"飛",OU:"玉",TO:"と",NY:"成香",NK:"成桂",NG:"成銀",UM:"馬",RY:"龍"};
+  return map[kind] || kind;
+}
+
+function colorName(color){ return color==0?"先手":"後手"; }
+
+async function loadState(){
+  const res = await fetch('/state');
+  state = await res.json();
+  render();
+}
+
+function render(){
+  const board = document.getElementById('board');
+  board.innerHTML='';
+  for(let y=9;y>=1;y--){
+    for(let x=1;x<=9;x++){
+      const cell=document.createElement('div');
+      cell.className='cell';
+      cell.dataset.x=x; cell.dataset.y=y;
+      const p=state.board[y-1][x-1];
+      if(p){
+        const div=document.createElement('div');
+        div.className='piece '+(p.color===1?'white':'black');
+        div.draggable=true;
+        div.dataset.x=x; div.dataset.y=y;
+        div.innerText=pieceKanji(p.kind);
+        cell.appendChild(div);
+      }
+      board.appendChild(cell);
+    }
+  }
+  renderHands('black-hands', state.hands[0], 'black');
+  renderHands('white-hands', state.hands[1], 'white');
+  document.getElementById('turn').innerText=colorName(state.turn)+"の番";
+  document.getElementById('message').innerText=state.message||'';
+}
+
+function renderHands(id, list, cls){
+  const el=document.getElementById(id);
+  el.innerHTML='';
+  const counts={};
+  for(const k of list){counts[k]=(counts[k]||0)+1;}
+  for(const k in counts){
+    const div=document.createElement('div');
+    div.className='piece '+cls;
+    div.draggable=true;
+    div.dataset.kind=k;
+    div.innerText=pieceKanji(k)+counts[k];
+    el.appendChild(div);
+  }
+}
+
+document.addEventListener('dragstart', async e=>{
+  if(!e.target.classList.contains('piece')) return;
+  const x=e.target.dataset.x;
+  const y=e.target.dataset.y;
+  if(x&&y){
+    const res=await fetch(`/moves?x=${x}&y=${y}`);
+    const data=await res.json();
+    highlight(data.moves);
+    e.dataTransfer.setData('text/plain', JSON.stringify({type:'move',x,y}));
+  }else if(e.target.dataset.kind){
+    const kind=e.target.dataset.kind;
+    const res=await fetch(`/drops?kind=${kind}`);
+    const data=await res.json();
+    highlight(data.drops);
+    e.dataTransfer.setData('text/plain', JSON.stringify({type:'drop',kind}));
+  }
+});
+
+document.addEventListener('dragend',()=>highlight([]));
+
+document.addEventListener('dragover',e=>{
+  if(e.target.closest('.cell')) e.preventDefault();
+});
+
+document.addEventListener('drop', async e=>{
+  const cell=e.target.closest('.cell');
+  if(!cell) return;
+  e.preventDefault();
+  const data=JSON.parse(e.dataTransfer.getData('text/plain'));
+  const x=cell.dataset.x; const y=cell.dataset.y;
+  if(data.type==='move'){
+    const res=await fetch('/move',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({from:{x:data.x,y:data.y},to:{x,y}})});
+    state=await res.json();
+    render();
+  }else if(data.type==='drop'){
+    const res=await fetch('/move',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({drop:{kind:data.kind,x,y}})});
+    state=await res.json();
+    render();
+  }
+});
+
+function highlight(cells){
+  document.querySelectorAll('.cell').forEach(c=>c.classList.remove('highlight'));
+  cells.forEach(pos=>{
+    const cell=document.querySelector(`.cell[data-x='${pos.x}'][data-y='${pos.y}']`);
+    if(cell) cell.classList.add('highlight');
+  });
+}
+
+document.getElementById('undo').addEventListener('click', async ()=>{
+  const res=await fetch('/undo',{method:'POST'});
+  state=await res.json();
+  render();
+});
+
+loadState();

--- a/index.html
+++ b/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<title>AI対戦将棋</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<h1>AI対戦将棋</h1>
+<div id="turn"></div>
+<button id="undo">待った</button>
+<div id="message"></div>
+<div id="white-hands" class="hands"></div>
+<div id="board" class="board"></div>
+<div id="black-hands" class="hands"></div>
+<script src="app.js"></script>
+</body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,18 @@
+{
+  "name": "test2",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "shogi.js": "^5.4.1"
+      }
+    },
+    "node_modules/shogi.js": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/shogi.js/-/shogi.js-5.4.1.tgz",
+      "integrity": "sha512-63YlCIN9IMbDvqUaCAKT77KCl7es+KQjXCdFx0nSZ3Fgth71qvZZuDQD9fqGKuVswdX00WFtiM97qzh1ZJ55sA==",
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "shogi.js": "^5.4.1"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,174 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const { Shogi, Color } = require('shogi.js');
+
+let game = new Shogi();
+let history = [];
+
+function sendFile(res, filepath, type) {
+  fs.readFile(filepath, (err, data) => {
+    if (err) {
+      res.writeHead(404);
+      res.end('not found');
+    } else {
+      res.writeHead(200, { 'Content-Type': type });
+      res.end(data);
+    }
+  });
+}
+
+function getState() {
+  const board = [];
+  for (let y = 1; y <= 9; y++) {
+    const row = [];
+    for (let x = 1; x <= 9; x++) {
+      const p = game.get(x, y);
+      row.push(p ? { color: p.color, kind: p.kind } : null);
+    }
+    board.push(row);
+  }
+  return {
+    board,
+    hands: {
+      0: game.hands[Color.Black].map(p => p.kind),
+      1: game.hands[Color.White].map(p => p.kind)
+    },
+    turn: game.turn,
+    message: ''
+  };
+}
+
+function hasMove(color) {
+  for (let x = 1; x <= 9; x++) {
+    for (let y = 1; y <= 9; y++) {
+      const p = game.get(x, y);
+      if (p && p.color === color && game.getMovesFrom(x, y).length > 0) {
+        return true;
+      }
+    }
+  }
+  if (game.getDropsBy(color).length > 0) return true;
+  return false;
+}
+
+function isKingCaptured() {
+  let b = false;
+  let w = false;
+  for (let x = 1; x <= 9; x++) {
+    for (let y = 1; y <= 9; y++) {
+      const p = game.get(x, y);
+      if (p && p.kind === 'OU') {
+        if (p.color === Color.Black) b = true; else w = true;
+      }
+    }
+  }
+  return !(b && w);
+}
+
+function aiMove() {
+  const color = game.turn;
+  const moves = [];
+  for (let x = 1; x <= 9; x++) {
+    for (let y = 1; y <= 9; y++) {
+      const p = game.get(x, y);
+      if (p && p.color === color) {
+        game.getMovesFrom(x, y).forEach(m => moves.push({ type: 'move', from: m.from, to: m.to }));
+      }
+    }
+  }
+  game.getDropsBy(color).forEach(d => moves.push({ type: 'drop', to: d.to, kind: d.kind }));
+  if (moves.length === 0) return;
+  const mv = moves[Math.floor(Math.random() * moves.length)];
+  history.push(game.toSFENString());
+  if (mv.type === 'move') {
+    game.move(mv.from.x, mv.from.y, mv.to.x, mv.to.y, true);
+  } else {
+    game.drop(mv.to.x, mv.to.y, mv.kind, color);
+  }
+}
+
+function handleMessage() {
+  let message = '';
+  const opp = game.turn === Color.Black ? Color.White : Color.Black;
+  if (isKingCaptured()) {
+    message = (opp === Color.Black ? '先手' : '後手') + 'の勝ち！';
+    game = new Shogi();
+    history = [];
+  } else if (!hasMove(game.turn) && game.isCheck(game.turn)) {
+    message = (game.turn === Color.Black ? '先手' : '後手') + 'は詰みです。';
+  } else if (game.isCheck(game.turn)) {
+    message = '王手！';
+  }
+  return message;
+}
+
+const server = http.createServer((req, res) => {
+  if (req.method === 'GET') {
+    if (req.url === '/' || req.url === '/index.html') {
+      return sendFile(res, path.join(__dirname, 'index.html'), 'text/html');
+    } else if (req.url === '/app.js') {
+      return sendFile(res, path.join(__dirname, 'app.js'), 'application/javascript');
+    } else if (req.url === '/style.css') {
+      return sendFile(res, path.join(__dirname, 'style.css'), 'text/css');
+    } else if (req.url.startsWith('/state')) {
+      const st = getState();
+      st.message = handleMessage();
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      return res.end(JSON.stringify(st));
+    } else if (req.url.startsWith('/moves')) {
+      const u = new URL(req.url, 'http://localhost');
+      const x = parseInt(u.searchParams.get('x'));
+      const y = parseInt(u.searchParams.get('y'));
+      const moves = game.getMovesFrom(x, y).map(m => m.to);
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      return res.end(JSON.stringify({ moves }));
+    } else if (req.url.startsWith('/drops')) {
+      const u = new URL(req.url, 'http://localhost');
+      const kind = u.searchParams.get('kind');
+      const color = game.turn;
+      const drops = game.getDropsBy(color).filter(d => d.kind === kind).map(d => d.to);
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      return res.end(JSON.stringify({ drops }));
+    }
+    res.writeHead(404); res.end('not found');
+  } else if (req.method === 'POST') {
+    if (req.url === '/move') {
+      let body = '';
+      req.on('data', c => body += c);
+      req.on('end', () => {
+        try {
+          const data = JSON.parse(body);
+          history.push(game.toSFENString());
+          if (data.from) {
+            game.move(+data.from.x, +data.from.y, +data.to.x, +data.to.y, true);
+          } else if (data.drop) {
+            game.drop(+data.drop.x, +data.drop.y, data.drop.kind);
+          }
+          if (!isKingCaptured()) aiMove();
+          const st = getState();
+          st.message = handleMessage();
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify(st));
+        } catch (e) {
+          if (history.length) game.initializeFromSFENString(history.pop());
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify(getState()));
+        }
+      });
+    } else if (req.url === '/undo') {
+      if (history.length) {
+        const s = history.pop();
+        game.initializeFromSFENString(s);
+      }
+      const st = getState();
+      st.message = handleMessage();
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(st));
+    } else {
+      res.writeHead(404); res.end('not found');
+    }
+  }
+});
+
+server.listen(3000, () => console.log('Server running on http://localhost:3000'));

--- a/style.css
+++ b/style.css
@@ -1,0 +1,8 @@
+body { font-family: sans-serif; text-align: center; }
+.board { display: grid; grid-template-columns: repeat(9, 60px); margin: 10px auto; }
+.cell { width: 60px; height: 60px; border: 1px solid #333; position: relative; }
+.piece { width: 100%; height: 100%; display: flex; justify-content: center; align-items: center; font-size: 24px; cursor: move; }
+.white { transform: rotate(180deg); }
+.hands { display: flex; justify-content: center; margin: 5px; }
+.hands .piece { width: 40px; height: 40px; border: 1px solid #333; margin: 2px; }
+.highlight { background: #fffa90; }


### PR DESCRIPTION
## Summary
- add basic web UI for Shogi (board, hands, undo button)
- implement client-side drag & drop logic with highlighting
- add Node server using `shogi.js` to manage the game and provide a random-move AI opponent
- configure `.gitignore`

## Testing
- `node server.js`

------
https://chatgpt.com/codex/tasks/task_e_686c8838808483259be04ab564d81f4e