### PR TITLE
Improve AI thinking display and search logic

### DIFF
--- a/aiWorker.js
+++ b/aiWorker.js
@@ -1,0 +1,200 @@
+const PROMOTE={P:"+P",L:"+L",N:"+N",S:"+S",B:"+B",R:"+R"};
+const UNPROMOTE={"+P":"P","+L":"L","+N":"N","+S":"S","+B":"B","+R":"R"};
+const PROMOTABLE={P:1,L:1,N:1,S:1,B:1,R:1};
+let stop=false;
+let bestMove=null;
+let startTime=0;
+let respectTime=true;
+const TT=new Map();
+self.onmessage=e=>{
+  const d=e.data;
+  if(d.type==='start'){
+    stop=false;
+    bestMove=null;
+    respectTime=true;
+    const time=iterative(d.state);
+    postMessage({move:bestMove,time});
+  }else if(d.type==='stop'){
+    stop=true;
+    postMessage({move:bestMove,time:Date.now()-startTime});
+  }
+};
+function iterative(state){
+  startTime=Date.now();
+  const legal=generateLegalMoves(state,state.turn);
+  if(legal.length===0){bestMove=null;return Date.now()-startTime;}
+  for(let depth=1;depth<=7;depth++){
+    const [v,m]=search(state,depth,-1e9,1e9,true);
+    if(stop)break;
+    if(m)bestMove=m;
+    if(Date.now()-startTime>10000 && bestMove)break;
+  }
+  if(!bestMove){
+    respectTime=false;
+    const [v,m]=search(state,1,-1e9,1e9,true);
+    bestMove=m;
+    respectTime=true;
+  }
+  return Date.now()-startTime;
+}
+function search(s,depth,alpha,beta,root){
+  if(stop||(respectTime && Date.now()-startTime>10000))return[evalState(s),null];
+  if(depth===0)return[evalState(s),null];
+  const key=hashState(s);
+  const tt=TT.get(key);
+  if(tt && tt.depth>=depth)return[tt.score,tt.move];
+  const moves=generateLegalMoves(s,s.turn);
+  let best=null;
+  if(root)moves.sort(()=>Math.random()-0.5);
+  for(const mv of moves){
+    const ns=clone(s);
+    applyMove(ns,mv);
+    const [v]=search(ns,depth-1,-beta,-alpha,false);
+    const score=-v;
+    if(score>alpha){
+      alpha=score;best=mv;
+      if(alpha>=beta)break;
+    }
+    if(stop||(respectTime && Date.now()-startTime>10000))break;
+  }
+  TT.set(key,{depth,score:alpha,move:best});
+  if(TT.size>10000)TT.delete(TT.keys().next().value);
+  return[alpha,best];
+}
+function evalState(s){
+  const val={P:100,L:300,N:300,S:400,G:500,B:700,R:800,K:0,'+P':500,'+L':500,'+N':500,'+S':500,'+B':900,'+R':1000};
+  let v=0;
+  for(let i=0;i<81;i++){
+    const p=s.board[i];
+    if(p){
+      v+=(p.c? -1:1)*val[p.t];
+      const r=Math.floor(i/9);
+      const prog=p.c? r:8-r;
+      v+=(p.c? -1:1)*prog*10;
+    }
+  }
+  for(let c=0;c<2;c++){
+    const h=s.hand[c];
+    for(let k in h)v+=(c? -1:1)*val[k]*(h[k]||0);
+  }
+  return v;
+}
+function hashState(s){
+  let str=s.turn;
+  for(let i=0;i<81;i++){
+    const p=s.board[i];
+    if(p)str+=p.t+p.c;else str+='.';
+  }
+  str+='|'+JSON.stringify(s.hand[0])+JSON.stringify(s.hand[1]);
+  return str;
+}
+// helper functions compatible with main thread
+function clone(s){
+  return{board:s.board.map(p=>p?{t:p.t,c:p.c}:null),hand:s.hand.map(h=>({...h})),turn:s.turn};
+}
+function applyMove(s,m){
+  if(m.from>=0){
+    const p=s.board[m.from];
+    s.board[m.from]=null;
+    if(m.capture)s.hand[p.c][m.capture]=(s.hand[p.c][m.capture]||0)+1;
+    if(m.promote)p.t=m.promoteTo;
+    s.board[m.to]=p;
+  }else{
+    s.hand[s.turn][m.drop]--;
+    s.board[m.to]={t:m.drop,c:s.turn};
+  }
+  s.turn^=1;
+}
+function generateLegalMoves(s,color){
+  const moves=generateMoves(s,color);
+  return moves.filter(m=>{const ns=clone(s);applyMove(ns,m);return !isCheck(ns,color);});
+}
+function generateMoves(s,color){
+  const moves=[];
+  for(let i=0;i<81;i++){
+    const p=s.board[i];
+    if(!p||p.c!==color)continue;
+    genPieceMoves(i,p.t,color,s.board,moves);
+  }
+  const hand=s.hand[color];
+  for(let k in hand){
+    if(hand[k]>0){
+      for(let i=0;i<81;i++)if(!s.board[i]){
+        if(k==='P'&&invalidPawnDrop(i,color,s))continue;
+        moves.push({from:-1,to:i,drop:k});
+      }
+    }
+  }
+  return moves;
+}
+function invalidPawnDrop(to,color,s){
+  const file=to%9;
+  for(let r=0;r<9;r++){const p=s.board[r*9+file];if(p&&p.c===color&&p.t==='P')return true;}
+  const ns=clone(s);applyMove(ns,{from:-1,to,drop:'P'});return isMate(ns,color^1);
+}
+function genPieceMoves(idx,type,c,b,moves){
+  const dirs={
+    P:[[0,1]],
+    L:[[0,1,true]],
+    N:[[1,2],[-1,2]],
+    S:[[0,1],[1,1],[-1,1],[1,-1],[-1,-1]],
+    G:[[0,1],[1,1],[-1,1],[1,0],[-1,0],[0,-1]],
+    K:[[0,1],[1,1],[-1,1],[1,0],[-1,0],[0,-1],[1,-1],[-1,-1]],
+    B:[[1,1,true],[-1,1,true],[1,-1,true],[-1,-1,true]],
+    R:[[0,1,true],[0,-1,true],[1,0,true],[-1,0,true]]
+  };
+  const add=(dx,dy,slide)=>{
+    let x=idx%9,y=8-Math.floor(idx/9);if(c)dy=-dy;
+    for(let n=1;;n++){
+      const nx=x+dx*n,ny=y+dy*n;if(nx<0||nx>8||ny<0||ny>8)break;
+      const ni=(8-ny)*9+nx;const t=b[ni];
+      const promo=needPromote(type,c,idx,ni);
+      const addMove=(pr)=>{
+        const mv={from:idx,to:ni};
+        if(pr){mv.promote=true;mv.promoteTo=PROMOTE[type];}
+        if(t&&t.c!==c)mv.capture=UNPROMOTE[t.t]||t.t;
+        moves.push(mv);
+      };
+      if(!t){
+        addMove(false);
+        if(promo)addMove(true);
+      }else{
+        if(t.c!==c){
+          addMove(false);
+          if(promo)addMove(true);
+        }
+        break;
+      }
+      if(!slide)break;
+    }
+  };
+  let ps=dirs[type];
+  if(!ps&&type[0]==='+')ps=dirs.G;
+  if(type==='+B')ps=dirs.B.concat(dirs.R);
+  if(type==='+R')ps=dirs.R.concat(dirs.B);
+  if(!ps)return;
+  for(const d of ps)add(d[0],d[1],d[2]);
+}
+function needPromote(type,c,from,to){
+  if(!PROMOTABLE[type])return false;
+  const fy=8-Math.floor(from/9),ty=8-Math.floor(to/9);
+  const zone=y=>c?y<3:y>5;
+  return zone(fy)||zone(ty);
+}
+function isCheck(s,color){
+  const k=findKing(s,color);
+  return attacksTo(s,k,color^1).length>0;
+}
+function findKing(s,color){
+  for(let i=0;i<81;i++){const p=s.board[i];if(p&&p.c===color&&p.t==='K')return i;}
+  return -1;
+}
+function attacksTo(s,idx,att){
+  const moves=[];
+  for(let i=0;i<81;i++){const p=s.board[i];if(p&&p.c===att)genPieceMoves(i,p.t,att,s.board,moves);}
+  return moves.filter(m=>m.to===idx);
+}
+function isMate(s,color){
+  if(!isCheck(s,color))return false;
+  return generateLegalMoves(s,color).length===0;
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<title>将棋AI</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<div id="app">
+  <div class="handBox"><span class="handLabel">後手（コンピュータ）持ち駒:</span><div id="hand1" class="hand"></div></div>
+  <div id="board" class="board"></div>
+  <div class="handBox"><span class="handLabel">先手（あなた）持ち駒:</span><div id="hand0" class="hand"></div></div>
+  <div id="info">
+    <span id="turn">先手番</span>
+    <span id="moveCount">手数:0</span>
+    <button id="undo">待った</button>
+    <button id="reset" style="display:none">リセット</button>
+    <span id="status"></span>
+  </div>
+</div>
+<script src="shogi.js"></script>
+</body>
+</html>

--- a/shogi.js
+++ b/shogi.js
@@ -1,0 +1,269 @@
+const PIECE_NAMES={
+  P:'\u6b69',L:'\u9999',N:'\u6842',S:'\u9280',G:'\u91d1',B:'\u89d2',R:'\u98db',K:'\u7389',
+  '+P':'\u3068','+L':'\u6210\u9999','+N':'\u6210\u6842','+S':'\u6210\u9280','+B':'\u99ac','+R':'\u7adc'
+};
+const PROMOTABLE={P:1,L:1,N:1,S:1,B:1,R:1};
+const PROMOTE={'P':'+P','L':'+L','N':'+N','S':'+S','B':'+B','R':'+R'};
+const UNPROMOTE={'+P':'P','+L':'L','+N':'N','+S':'S','+B':'B','+R':'R'};
+const HUMAN=0; // player side
+function initialState(){
+  const b=Array(81).fill(null);
+  const s=['L','N','S','G','K','G','S','N','L',null,'R',null,null,null,null,null,'B',null];
+  for(let i=0;i<9;i++){b[i]= {type:s[i],c:1};}
+  b[10]={type:'R',c:1}; b[16]={type:'B',c:1};
+  for(let i=18;i<27;i++)b[i]={type:'P',c:1};
+  for(let i=54;i<63;i++)b[i]={type:'P',c:0};
+  b[64]={type:'B',c:0}; b[70]={type:'R',c:0};
+  const t=['L','N','S','G','K','G','S','N','L'];
+  for(let i=72;i<81;i++)b[i]={type:t[i-72],c:0};
+  return {board:b,hand:[{},{}],turn:0,history:[]};
+}
+let state=initialState();
+const boardEl=document.getElementById('board');
+const handEls=[document.getElementById('hand0'),document.getElementById('hand1')];
+const statusEl=document.getElementById('status');
+const moveEl=document.getElementById('moveCount');
+const resetBtn=document.getElementById('reset');
+let timerId=null;
+let thinkStart=0;
+resetBtn.onclick=resetGame;
+
+function resetGame(){
+  worker.postMessage({type:'stop'});
+  state=initialState();
+  render();
+  statusEl.textContent='';
+  resetBtn.style.display='none';
+}
+function render(){
+  boardEl.innerHTML='';
+  for(let i=0;i<81;i++){
+    const cell=document.createElement('div');
+    cell.className='cell';
+    cell.dataset.index=i;
+    const p=state.board[i];
+    if(p){
+      const el=document.createElement('div');
+      el.className='piece'+(p.c? ' white':'')+(p.type[0]==='+'?' promoted':'');
+      el.textContent=PIECE_NAMES[p.type];
+      el.onclick=()=>selectFrom(i);
+      cell.appendChild(el);
+    }
+    boardEl.appendChild(cell);
+  }
+  for(let c=0;c<2;c++){
+    const h=handEls[c];
+    h.innerHTML='';
+    const hand=state.hand[c];
+    for(let k in hand){
+      if(hand[k]>0){
+        const el=document.createElement('span');
+        el.className='handPiece'+(c? ' white':'');
+        el.textContent=PIECE_NAMES[k]+(hand[k]>1?hand[k]:'');
+        el.onclick=()=>selectHand(k,c);
+        h.appendChild(el);
+      }
+    }
+  }
+  document.getElementById('turn').textContent=state.turn? '後手番':'先手番';
+  moveEl.textContent='手数:' + state.history.length;
+}
+let selected=null;
+let legal=[];
+let ignore=false;
+function startThinking(){
+  thinkStart=Date.now();
+  statusEl.textContent='考え中...0.0秒';
+  timerId=setInterval(()=>{
+    statusEl.textContent='考え中...'+((Date.now()-thinkStart)/1000).toFixed(1)+'秒';
+  },100);
+}
+function stopThinking(ms){
+  clearInterval(timerId);
+  statusEl.textContent='思考時間:'+ (ms/1000).toFixed(1)+'秒';
+}
+function selectFrom(i){
+  if(state.turn!==HUMAN)return;
+  const p=state.board[i];
+  if(!p||p.c!==HUMAN)return;
+  selected={from:i,piece:p};
+  legal=generateLegalMoves(state,p.c).filter(m=>m.from===i);
+  highlight();
+}
+function selectHand(type,c){
+  if(c!==HUMAN||state.turn!==HUMAN)return;
+  selected={from:-1,type};
+  legal=generateLegalMoves(state,c).filter(m=>m.drop===type);
+  highlight();
+}
+function highlight(){
+  document.querySelectorAll('.cell').forEach(cell=>cell.classList.remove('highlight'));
+  legal.forEach(m=>{
+    const idx=m.to;
+    boardEl.children[idx].classList.add('highlight');
+  });
+}
+boardEl.onclick=e=>{
+  if(state.turn!==HUMAN)return;
+  const idx=Number(e.target.closest('.cell')?.dataset.index);
+  if(selected){
+    const mv=legal.find(m=>m.to===idx);
+    if(mv){
+      playMove(mv);
+      selected=null;legal=[];highlight();
+    }
+  }
+};
+document.getElementById('undo').onclick=()=>{
+  if(state.history.length<2)return;
+  ignore=true;
+  worker.postMessage({type:'stop'});
+  stopThinking(Date.now()-thinkStart);
+  undo();undo();
+  render();
+};
+function playMove(m){
+  applyMove(state,m);
+  render();
+  state.history.push(m);
+  if(generateLegalMoves(state,state.turn).length===0){
+    statusEl.textContent='後手の負けです';
+    resetBtn.style.display='inline';
+    return;
+  }
+  startThinking();
+  worker.postMessage({type:'start',state:serialize(state)});
+}
+function applyMove(s,m){
+  if(m.from>=0){
+    const p=s.board[m.from];
+    s.board[m.from]=null;
+    const toPiece=s.board[m.to];
+    if(toPiece){
+      m.captured={type:toPiece.type,c:toPiece.c};
+      const t=UNPROMOTE[toPiece.type]||toPiece.type;
+      s.hand[p.c][t]=(s.hand[p.c][t]||0)+1;
+    } else m.captured=null;
+    if(m.promote)p.type= PROMOTE[p.type];
+    s.board[m.to]=p;
+  }else{
+    s.hand[s.turn][m.drop]--;
+    s.board[m.to]={type:m.drop,c:s.turn};
+  }
+  s.turn^=1;
+}
+function undo(){
+  const m=state.history.pop();
+  state.turn^=1;
+  if(m.from>=0){
+    const p=state.board[m.to];
+    state.board[m.to]=null;
+    if(m.promote)p.type=UNPROMOTE[p.type];
+    state.board[m.from]=p;
+    if(m.captured){
+      const t=UNPROMOTE[m.captured.type]||m.captured.type;
+      state.hand[state.turn][t]--;
+      state.board[m.to]={type:m.captured.type,c:state.turn^1};
+    }
+  }else{
+    state.board[m.to]=null;
+    state.hand[state.turn][m.drop]=(state.hand[state.turn][m.drop]||0)+1;
+  }
+}
+function generateLegalMoves(s,color){
+  const moves=generateMoves(s,color);
+  return moves.filter(m=>{const ns=clone(s);applyMove(ns,m);return !isCheck(ns,color);});
+}
+function generateMoves(s,color){
+  const moves=[];
+  for(let i=0;i<81;i++){
+    const p=s.board[i];
+    if(!p||p.c!==color)continue;
+    const piece=p.type;
+    genPieceMoves(i,piece,color,s.board,moves);
+  }
+  const hand=s.hand[color];
+  for(let k in hand){
+    if(hand[k]>0){
+      for(let i=0;i<81;i++)if(!s.board[i]){
+        if(k==='P'&&invalidPawnDrop(i,color,s))continue;
+        const m={from:-1,to:i,drop:k};
+        moves.push(m);
+      }
+    }
+  }
+  return moves;
+}
+function invalidPawnDrop(to,color,s){
+  const file=to%9;
+  for(let r=0;r<9;r++){
+    const p=s.board[r*9+file];
+    if(p&&p.c===color&&p.type==='P')return true;
+  }
+  const ns=clone(s);applyMove(ns,{from:-1,to,drop:'P'});return isMate(ns,color^1);
+}
+function genPieceMoves(idx,type,c,b,moves){
+  const dirs={
+    P:[[0,1]],
+    L:[[0,1,true]],
+    N:[[1,2],[-1,2]],
+    S:[[0,1],[1,1],[-1,1],[1,-1],[-1,-1]],
+    G:[[0,1],[1,1],[-1,1],[1,0],[-1,0],[0,-1]],
+    K:[[0,1],[1,1],[-1,1],[1,0],[-1,0],[0,-1],[1,-1],[-1,-1]],
+    B:[[1,1,true],[-1,1,true],[1,-1,true],[-1,-1,true]],
+    R:[[0,1,true],[0,-1,true],[1,0,true],[-1,0,true]]
+  };
+  const add=(dx,dy,slide)=>{
+    let x=idx%9,y=8-Math.floor(idx/9); if(c)dy=-dy;
+    for(let n=1;;n++){
+      const nx=x+dx*n,ny=y+dy*n; if(nx<0||nx>8||ny<0||ny>8)break;
+      const ni=(8-ny)*9+nx; const t=b[ni];
+      if(!t){moves.push({from:idx,to:ni,promote:needPromote(type,c,idx,ni)})}else{if(t.c!==c)moves.push({from:idx,to:ni,promote:needPromote(type,c,idx,ni),capture:UNPROMOTE[t.type]||t.type});break;}if(!slide)break;
+    }
+  };
+  let ps=dirs[type]; if(!ps&&type[0]==='+'){ps=dirs.G;} if(type==='+B'){ps=dirs.B.concat(dirs.R);} if(type==='+R'){ps=dirs.R.concat(dirs.B);} if(!ps)return; for(const d of ps)add(d[0],d[1],d[2]);
+}
+function needPromote(type,c,from,to){
+  if(!PROMOTABLE[type])return false;
+  const zy=(y)=>c?y<3:y>5;
+  const fy=8-Math.floor(from/9),ty=8-Math.floor(to/9);
+  return zy(fy)||zy(ty);
+}
+function isCheck(s,color){
+  const k=findKing(s,color);return attacksTo(s,k,color^1).length>0;
+}
+function findKing(s,color){
+  for(let i=0;i<81;i++){const p=s.board[i]; if(p&&p.c===color&&p.type==='K')return i;}return -1;}
+function attacksTo(s,idx,attacker){
+  const b=s.board; const moves=[]; for(let i=0;i<81;i++){const p=b[i]; if(p&&p.c===attacker)genPieceMoves(i,p.type,attacker,b,moves);} return moves.filter(m=>m.to===idx);
+}
+function isMate(s,color){
+  if(!isCheck(s,color))return false; return generateLegalMoves(s,color).length===0;
+}
+function clone(s){
+  return {board:s.board.map(p=>p?{type:p.type,c:p.c}:null),hand:[{...s.hand[0]},{...s.hand[1]}],turn:s.turn};
+}
+function serialize(s){
+  return {board:s.board.map(p=>p?{t:p.type,c:p.c}:null),hand:s.hand.map(h=>({...h})),turn:s.turn};
+}
+
+render();
+const worker=new Worker('aiWorker.js');
+worker.onmessage=e=>{
+  if(ignore){ignore=false;return;}
+  const {move,time}=e.data;
+  stopThinking(time);
+  if(!move){
+    statusEl.textContent='後手の負けです';
+    resetBtn.style.display='inline';
+    return;
+  }
+  applyMove(state,move);
+  state.history.push(move);
+  render();
+  if(generateLegalMoves(state,state.turn).length===0){
+    statusEl.textContent='先手の負けです';
+    resetBtn.style.display='inline';
+    return;
+  }
+};

--- a/style.css
+++ b/style.css
@@ -1,0 +1,87 @@
+body {
+  background:#222;
+  color:#eee;
+  font-family:sans-serif;
+  text-align:center;
+}
+#info{
+  display:flex;
+  justify-content:space-between;
+  align-items:center;
+  width:640px;
+  margin:4px auto;
+}
+#status{margin-left:8px;}
+.board {
+  background:#deb887;
+  display:grid;
+  grid-template-columns:repeat(9,1fr);
+  width:640px;
+  height:640px;
+  margin:10px auto;
+  border:2px solid #555;
+}
+.cell {
+  border:1px solid #555;
+  position:relative;
+  background:#f5deb3;
+}
+.piece {
+  position:absolute;
+  width:100%;
+  height:100%;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  font-size:32px;
+  cursor:pointer;
+  user-select:none;
+  font-family:'Yu Mincho', 'Hiragino Mincho ProN', 'serif';
+  color:#000;
+}
+.white {
+  transform:rotate(180deg);
+}
+.hand {
+  display:flex;
+  justify-content:center;
+  gap:4px;
+  min-height:40px;
+}
+.handPiece {
+  border:1px solid #888;
+  padding:2px 4px;
+  cursor:pointer;
+  color:#000;
+  background:#f5deb3;
+}
+.handBox{
+  display:flex;
+  justify-content:center;
+  align-items:center;
+  gap:4px;
+  width:640px;
+  margin:4px auto;
+}
+.handLabel{
+  color:#eee;
+}
+.promoted {
+  color:red;
+}
+.highlight {
+  background:rgba(255,255,0,0.3);
+}
+.modal {
+  position:fixed;
+  top:0;left:0;
+  width:100%;height:100%;
+  background:rgba(0,0,0,0.7);
+  display:flex;
+  align-items:center;
+  justify-content:center;
+}
+.modalContent{
+  background:#333;
+  padding:20px;
+}


### PR DESCRIPTION
## Summary
- show move count and AI thinking timer in the UI
- stop and display thinking time when a move is returned
- undo stops current search
- strengthen search with transposition table and deeper search
- add reset button that appears on game over and starts a new game

## Testing
- `python test`


------
https://chatgpt.com/codex/tasks/task_e_686cae2143888325b2555d4ab793a0ba