### PR TITLE
Add reset button, move log, and faster AI

### DIFF
--- a/aiWorker.js
+++ b/aiWorker.js
@@ -6,6 +6,18 @@ let bestMove=null;
 let startTime=0;
 let respectTime=true;
 const TT=new Map();
+
+function orderMoves(moves){
+  return moves.sort((a,b)=>{
+    const score=(m)=>{
+      let s=0;
+      if(m.capture)s+=5;
+      if(m.promote)s+=2;
+      return s;
+    };
+    return score(b)-score(a);
+  });
+}
 self.onmessage=e=>{
   const d=e.data;
   if(d.type==='start'){
@@ -23,11 +35,12 @@ function iterative(state){
   startTime=Date.now();
   const legal=generateLegalMoves(state,state.turn);
   if(legal.length===0){bestMove=null;return Date.now()-startTime;}
+  orderMoves(legal);
   for(let depth=1;depth<=7;depth++){
     const [v,m]=search(state,depth,-1e9,1e9,true);
     if(stop)break;
     if(m)bestMove=m;
-    if(Date.now()-startTime>10000 && bestMove)break;
+    if(Date.now()-startTime>5000 && bestMove)break;
   }
   if(!bestMove){
     respectTime=false;
@@ -38,14 +51,13 @@ function iterative(state){
   return Date.now()-startTime;
 }
 function search(s,depth,alpha,beta,root){
-  if(stop||(respectTime && Date.now()-startTime>10000))return[evalState(s),null];
+  if(stop||(respectTime && Date.now()-startTime>5000))return[evalState(s),null];
   if(depth===0)return[evalState(s),null];
   const key=hashState(s);
   const tt=TT.get(key);
   if(tt && tt.depth>=depth)return[tt.score,tt.move];
-  const moves=generateLegalMoves(s,s.turn);
+  const moves=orderMoves(generateLegalMoves(s,s.turn));
   let best=null;
-  if(root)moves.sort(()=>Math.random()-0.5);
   for(const mv of moves){
     const ns=clone(s);
     applyMove(ns,mv);
@@ -55,10 +67,10 @@ function search(s,depth,alpha,beta,root){
       alpha=score;best=mv;
       if(alpha>=beta)break;
     }
-    if(stop||(respectTime && Date.now()-startTime>10000))break;
+    if(stop||(respectTime && Date.now()-startTime>5000))break;
   }
   TT.set(key,{depth,score:alpha,move:best});
-  if(TT.size>10000)TT.delete(TT.keys().next().value);
+  if(TT.size>20000)TT.delete(TT.keys().next().value);
   return[alpha,best];
 }
 function evalState(s){

--- a/index.html
+++ b/index.html
@@ -14,8 +14,10 @@
     <span id="turn">先手番</span>
     <span id="moveCount">手数:0</span>
     <button id="undo">待った</button>
+    <button id="reset">リセット</button>
     <span id="status"></span>
   </div>
+  <div id="log" class="log"></div>
 </div>
 <script src="shogi.js"></script>
 </body>

--- a/shogi.js
+++ b/shogi.js
@@ -23,6 +23,8 @@ const boardEl=document.getElementById('board');
 const handEls=[document.getElementById('hand0'),document.getElementById('hand1')];
 const statusEl=document.getElementById('status');
 const moveEl=document.getElementById('moveCount');
+const logEl=document.getElementById('log');
+let logs=[];
 let timerId=null;
 let thinkStart=0;
 function render(){
@@ -93,6 +95,36 @@ function highlight(){
     boardEl.children[idx].classList.add('highlight');
   });
 }
+
+function idxToString(i){
+  const file=9-(i%9);
+  const rank=Math.floor(i/9)+1;
+  return file+''+rank;
+}
+
+function moveToString(m){
+  if(m.from>=0){
+    const from=idxToString(m.from);
+    const to=idxToString(m.to);
+    const p=state.board[m.to];
+    const name=PIECE_NAMES[p.type];
+    const cap=m.captured? 'x'+PIECE_NAMES[m.captured.type]:'';
+    const promo=m.promote? '成':'';
+    return name+from+cap+'-'+to+promo;
+  }else{
+    return PIECE_NAMES[m.drop]+'*'+idxToString(m.to);
+  }
+}
+
+function renderLog(){
+  logEl.innerHTML=logs.map(l=>'<div>'+l+'</div>').join('');
+  logEl.scrollTop=logEl.scrollHeight;
+}
+
+function addLog(player,m){
+  logs.push((player===HUMAN?'先手:':'後手:')+moveToString(m));
+  renderLog();
+}
 boardEl.onclick=e=>{
   if(state.turn!==HUMAN)return;
   const idx=Number(e.target.closest('.cell')?.dataset.index);
@@ -111,9 +143,22 @@ document.getElementById('undo').onclick=()=>{
   stopThinking(Date.now()-thinkStart);
   undo();undo();
   render();
+  renderLog();
 };
+
+function resetGame(){
+  ignore=true;
+  worker.postMessage({type:'stop'});
+  stopThinking(Date.now()-thinkStart);
+  state=initialState();
+  logs=[];
+  render();
+  renderLog();
+}
+document.getElementById('reset').onclick=resetGame;
 function playMove(m){
   applyMove(state,m);
+  addLog(HUMAN,m);
   render();
   state.history.push(m);
   startThinking();
@@ -154,6 +199,7 @@ function undo(){
     state.board[m.to]=null;
     state.hand[state.turn][m.drop]=(state.hand[state.turn][m.drop]||0)+1;
   }
+  logs.pop();
 }
 function generateLegalMoves(s,color){
   const moves=generateMoves(s,color);
@@ -243,6 +289,7 @@ worker.onmessage=e=>{
     return;
   }
   applyMove(state,move);
+  addLog(1,move);
   state.history.push(move);
   render();
 };

--- a/style.css
+++ b/style.css
@@ -85,3 +85,15 @@ body {
   background:#333;
   padding:20px;
 }
+
+#log{
+  width:640px;
+  margin:4px auto;
+  background:#333;
+  color:#eee;
+  text-align:left;
+  max-height:150px;
+  overflow-y:auto;
+  padding:4px;
+  font-size:14px;
+}


### PR DESCRIPTION
## Summary
- add reset button and move log to UI
- style log area
- record moves and allow resetting game state
- shorten AI think time and add simple move ordering

## Testing
- `python test`

------
https://chatgpt.com/codex/tasks/task_e_686d3ff385f88325a83e40b2d8c933b6